### PR TITLE
Centralize settings to aid development

### DIFF
--- a/osfoffline/alerts.py
+++ b/osfoffline/alerts.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
-from queue import Queue
 from datetime import datetime, timedelta
+from queue import Queue
 
 from PyQt5.QtWidgets import QSystemTrayIcon
+
+from osfoffline.settings import ALERT_TIME
+
 
 show_alerts = True
 
@@ -12,7 +15,6 @@ MODIFYING = 2
 DELETING = 3
 MOVING = 4
 
-ALERT_TIME = 1000
 
 alert_icon = None
 tray_alert_signal = None

--- a/osfoffline/application/background.py
+++ b/osfoffline/application/background.py
@@ -45,11 +45,8 @@ class BackgroundWorker(threading.Thread):
 
         if self.running:
             self.stop_polling_server()
-
             self.stop_observing_osf_folder()
-
             # self.stop_loop()
-
             self.running = False
 
     def start_polling_server(self):
@@ -110,9 +107,10 @@ class BackgroundWorker(threading.Thread):
         # LocalDBSync(self.user.osf_local_folder_path, self.observer, self.user).emit_new_events()
 
         try:
-
             self.observer.start()  # start
         except OSError:
+            # FIXME: Document these limits and provide better user notification.
+            #    See http://pythonhosted.org/watchdog/installation.html for limits.
             logging.warning('limit of watched items reached')
 
     def stop_observing_osf_folder(self):
@@ -137,23 +135,16 @@ class BackgroundWorker(threading.Thread):
         return asyncio.get_event_loop()
 
 
-"""
-HOW DOES LOGIN/LOGOUT WORK?
-
-previously logged in:
-when you first open osf offline, you go to main.py which sets up views, connections, and controller.
-controller sets up db, logs, and determines which user is logged in.
-when all is good, controller starts background worker.
-background worker polls api and observer osf folder
-
-not logged in:
-when you first open osf offline, you go to main.py which sets up views, connections, and controller.
-controller sets up db, logs, and opens create user screen. user logs in. then get user from db.
-when all is good, controller starts background worker.
-background worker polls api and observer osf folder
-
-
-
-
-
-"""
+# HOW DOES LOGIN/LOGOUT WORK?
+#
+# previously logged in:
+# when you first open osf offline, you go to main.py which sets up views, connections, and controller.
+# controller sets up db, logs, and determines which user is logged in.
+# when all is good, controller starts background worker.
+# background worker polls api and observer osf folder
+#
+# not logged in:
+# when you first open osf offline, you go to main.py which sets up views, connections, and controller.
+# controller sets up db, logs, and opens create user screen. user logs in. then get user from db.
+# when all is good, controller starts background worker.
+# background worker polls api and observer osf folder

--- a/osfoffline/database_manager/db.py
+++ b/osfoffline/database_manager/db.py
@@ -1,20 +1,19 @@
 import os
 
-from appdirs import user_data_dir
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
 from osfoffline.database_manager.models import Base
-from osfoffline.settings import PROJECT_NAME, PROJECT_AUTHOR
+from osfoffline.settings import DB_FILE_PATH, PROJECT_DB_PATH
 
-DB_DIR = user_data_dir(PROJECT_NAME, PROJECT_AUTHOR)
-DB_FILE_PATH = os.path.join(DB_DIR, 'osf.db')
+
 URL = 'sqlite:///{}'.format(DB_FILE_PATH)
 
 # sqlite+pysqlcipher://:passphrase/file_path
 # URL = 'sqlite+pysqlcipher://:PASSWORD/{DB_FILE_PATH}'.format(DB_FILE_PATH=DB_FILE_PATH)
 
-if not os.path.isdir(DB_DIR):
-    os.makedirs(DB_DIR)
+if not os.path.isdir(PROJECT_DB_PATH):
+    os.makedirs(PROJECT_DB_PATH)
+
 engine = create_engine(
     URL,
     # poolclass=SingletonThreadPool,

--- a/osfoffline/database_manager/utils.py
+++ b/osfoffline/database_manager/utils.py
@@ -1,7 +1,8 @@
 from contextlib import contextmanager
 import shutil
 
-from osfoffline.database_manager.db import session, DB_DIR
+from osfoffline.database_manager.db import session
+from osfoffline.settings import PROJECT_DB_PATH
 
 
 def save(session, *items_to_save):
@@ -28,7 +29,7 @@ def session_scope():
 
 
 def remove_db():
-    shutil.rmtree(DB_DIR)
+    shutil.rmtree(PROJECT_DB_PATH)
 
 
 

--- a/osfoffline/settings.py
+++ b/osfoffline/settings.py
@@ -1,55 +1,50 @@
 import logging
 import logging.config
+import os
 
 from appdirs import user_config_dir, user_data_dir
 
+## Development mode: use a local OSF dev version and more granular logging
+DEV_MODE = False  # TODO (abought): auto-set flag when using `inv start_for_tests`
+
+### General settings
 PROJECT_NAME = 'osf-offline'
 PROJECT_AUTHOR = 'cos'
-PROJECT_CONFIG_PATH = user_config_dir(PROJECT_NAME, PROJECT_AUTHOR)
-PROJECT_DB_PATH = user_data_dir(PROJECT_NAME, PROJECT_AUTHOR)
 
+### Variables used to control where application config data is stored
+PROJECT_CONFIG_PATH = user_config_dir(appname=PROJECT_NAME, appauthor=PROJECT_AUTHOR)
+PROJECT_DB_PATH = user_data_dir(appname=PROJECT_NAME, appauthor=PROJECT_AUTHOR)
+DB_FILE_PATH = os.path.join(PROJECT_DB_PATH, 'osf.db')
+
+### Base URL for API server; used to fetch data
 # API_BASE = 'http://localhost:5000'
-API_BASE = 'https://staging-api.osf.io'
-FILE_BASE = 'https://staging-files.osf.io'
+if DEV_MODE is True:
+    API_BASE = 'http://localhost:8000'
+    FILE_BASE = 'http://localhost:7777'  ## FIXME: Dev mode currently does not work with local waterbutler (abought)
+else:
+    API_BASE = 'https://staging-api.osf.io'
+    FILE_BASE = 'https://staging-files.osf.io'
+
+### Interval (in seconds) to poll the OSF for server-side file changes
+if DEV_MODE is True:
+    POLL_DELAY = 5  # seconds
+else:
+    POLL_DELAY = 10 * 60  # seconds
+
+### Time to keep alert messages on screen (in milliseconds); may not be configurable on all platforms
+ALERT_TIME = 1000  # ms
 
 
-
-# import hashlib
-#
-# try:
-#     from waterbutler import settings
-# except ImportError:
-#     settings = {}
-#
-# config = settings.get('SERVER_CONFIG', {})
-#
-#
-# ADDRESS = config.get('ADDRESS', '127.0.0.1')
-# PORT = config.get('PORT', 7777)
-#
-# DEBUG = config.get('DEBUG', True)
-#
-# CHUNK_SIZE = config.get('CHUNK_SIZE', 65536)  # 64KB
-# MAX_BODY_SIZE = config.get('MAX_BODY_SIZE', int(4.9 * (1024 ** 3)))  # 4.9 GB
-
-
-# try:
-#
-#     DEFAULT_FORMATTER = {
-#         '()': 'colorlog.ColoredFormatter',
-#         'format': '%(cyan)s[%(asctime)s]%(log_color)s[%(levelname)s][%(name)s]: %(reset)s%(message)s'
-#     }
-# except ImportError:
-#     DEFAULT_FORMATTER = {
-#         '()': 'waterbutler.core.logging.MaskFormatter',
-#         'format': '[%(asctime)s][%(levelname)s][%(name)s]: %(message)s',
-#         'pattern': '(?<=cookie=)(.*?)(?=&|$)',
-#         'mask': '***'
-#     }
+### Logging configuration
 DEFAULT_FORMATTER = {
     '()': 'colorlog.ColoredFormatter',
     'format': '%(cyan)s[%(asctime)s]%(log_color)s[%(threadName)s][%(filename)s][%(levelname)s][%(name)s]: %(reset)s%(message)s'
 }
+
+if DEV_MODE is True:
+    log_level = 'DEBUG'
+else:
+    log_level = 'INFO'
 
 DEFAULT_LOGGING_CONFIG = {
     'version': 1,
@@ -60,49 +55,30 @@ DEFAULT_LOGGING_CONFIG = {
     'handlers': {
         'console': {
             'class': 'logging.StreamHandler',
-            'level': 'INFO',
+            'level': log_level,
             'formatter': 'console'
         },
         'syslog': {
             'class': 'logging.handlers.SysLogHandler',
-            'level': 'INFO'
+            'level': log_level
         }
     },
     'loggers': {
         '': {
             'handlers': ['console'],
-            'level': 'INFO',
+            'level': log_level,
             'propagate': False
         }
     },
     'root': {
-        'level': 'INFO',
+        'level': log_level,
         'handlers': ['console']
     }
 }
 
-
-
-# try:
-#     config_path = os.environ['{}_CONFIG'.format(PROJECT_NAME.upper())]
-# except KeyError:
-#     env = os.environ.get('ENV', 'test')
-#     config_path = '{}/{}-{}.json'.format(PROJECT_CONFIG_PATH, PROJECT_NAME, env)
-#
-#
-# config = {}
-# config_path = os.path.expanduser(config_path)
-# if not os.path.exists(config_path):
-#     logging.warning('No \'{}\' configuration file found'.format(config_path))
-# else:
-#     with open(os.path.expanduser(config_path)) as fp:
-#         config = json.load(fp)
-#
-#
-# def get(key, default):
-#     return config.get(key, default)
-
-
-# logging_config = get('LOGGING', DEFAULT_LOGGING_CONFIG)
 logging_config = DEFAULT_LOGGING_CONFIG
 logging.config.dictConfig(logging_config)
+
+
+## TODO: Add a custom excepthook and implement logging to a file on user's hard drive (after cleanup PR)
+## logger.critical('Whatever', exc_info=(exc_type, exc_value, tb))

--- a/tasks.py
+++ b/tasks.py
@@ -48,12 +48,9 @@ def start():
 
 @task
 def start_for_tests():
-    import appdirs
     import shutil
-    from osfoffline.settings import PROJECT_NAME, PROJECT_AUTHOR
+    from osfoffline.settings import DB_FILE_PATH
 
-    DB_DIR = appdirs.user_data_dir(PROJECT_NAME, PROJECT_AUTHOR)
-    DB_FILE_PATH = os.path.join(DB_DIR, 'osf.db')
     if os.path.exists(DB_FILE_PATH):
         os.remove(DB_FILE_PATH)
 


### PR DESCRIPTION
## Purpose
Move commonly changed settings (like RECHECK_TIME and log level) into a single place to aid configuration.

Also begin work on a DEV_MODE flag, which would cause the client to work with a local copy of the OSF (instead of staging) and output more verbose log messages. This feature does not yet work; will talk to Himanshu about what waterbutler instance to use in the AM.