### PR TITLE
simplified move code

### DIFF
--- a/osfoffline/polling_osf_manager/osf_query.py
+++ b/osfoffline/polling_osf_manager/osf_query.py
@@ -158,8 +158,7 @@ class OSFQuery(object):
         url = remote.move_url
 
         data = {
-            'action': 'move',
-            'path': local.parent.osf_path if local.parent else '{}:{}'.format(local.node_id, local.provider),
+            'action': 'rename',
             'rename': local.name
         }
 


### PR DESCRIPTION
previously the issue was that I was using the move action for OSF Api's move endpoint. The move action also did allow for renaming files (very original design). However, I was messing something up in creating the path for the request. Instead of fixing the path, I changed it so we use the much simpler rename action. This does not require fixing the path.