### PR TITLE
Restore system tray icon on Mac os

### DIFF
--- a/osfoffline/views/system_tray.py
+++ b/osfoffline/views/system_tray.py
@@ -10,6 +10,8 @@ from PyQt5.QtWidgets import (QDialog, QSystemTrayIcon,
                              QAction, QMenu)
 import osfoffline.alerts as AlertHandler
 from osfoffline.utils.validators import validate_containing_folder
+import osfoffline.views.rsc.resources  # need this import for the logo to work properly.
+
 from PyQt5.QtCore import pyqtSignal
 
 


### PR DESCRIPTION
Refs https://openscience.atlassian.net/browse/OSF-5101

Fixes an issue where the system tray icon is an empty box on Mac OS (and possibly windows)

It appears that in the process of cleaning up imports, we removed one that wasn't used in *code*, but was required in order for QT to find and use assets.