### PR TITLE
Feature/fix items not syncing

### DIFF
--- a/osfoffline/views/preferences.py
+++ b/osfoffline/views/preferences.py
@@ -21,8 +21,8 @@ class Preferences(QDialog):
     OSF = 1
     ABOUT = 2
 
-    PROJECT_NAME_COLUMN = 0
-    PROJECT_SYNC_COLUMN = 1
+    PROJECT_NAME_COLUMN = 1
+    PROJECT_SYNC_COLUMN = 0
 
     preferences_closed_signal = pyqtSignal()
     containing_folder_updated_signal = pyqtSignal((str,))

--- a/osfoffline/views/rsc/preferences_rc.py
+++ b/osfoffline/views/rsc/preferences_rc.py
@@ -105,8 +105,8 @@ class Ui_Preferences(object):
         self.groupBox_4.setTitle(_translate("Preferences", "Project"))
         self.groupBox_5.setTitle(_translate("Preferences", "Choose Projects to Sync With"))
         self.changeFolderButton_2.setText(_translate("Preferences", "Update"))
-        self.treeWidget.headerItem().setText(0, _translate("Preferences", "Projects"))
-        self.treeWidget.headerItem().setText(1, _translate("Preferences", "Sync"))
+        self.treeWidget.headerItem().setText(0, _translate("Preferences", "Sync"))
+        self.treeWidget.headerItem().setText(1, _translate("Preferences", "Projects"))
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab_2), _translate("Preferences", "OSF"))
         self.textEdit_2.setHtml(_translate("Preferences", "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\">\n"
 "<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/css\">\n"


### PR DESCRIPTION
Purpose
-----------
Allow a user to drag a file into the root syncing folder, then drag the file into the project folder, and still get the file to sync into the project properly. Fixes [https://openscience.atlassian.net/browse/OSF-5121]

Secondarily, modified a small UI issue: swapped the column order on the preferences tab so that the checkboxes appeared first and the project items appeared second. It was a tiny change but should help immensely until further UI refinements can be added in.

Changes
----------
What was happening is that, once the file was seen by the desktop sync code, moving the file was considered a move, but moving only happens between projects. So I caught the case where it didn't really know where the file was being moved from and just said, well, if you don't know, then it must be a create action instead. I broke up the create into its own method that is separate from the event handler rather than trying to trigger a new event with the existing file.

For the UI change, I changed the ordering numbers in the constant for that control, and then I ensured that the numbers matched for the column labels.

Side effects
---------------
Hopefully none, but ¯\\\_(ツ)_/¯ 