### PR TITLE
Don't get registrations with the users/nodes

### DIFF
--- a/osfoffline/polling_osf_manager/api_url_builder.py
+++ b/osfoffline/polling_osf_manager/api_url_builder.py
@@ -29,6 +29,9 @@ def api_url_for(endpoint_type, related_type=None, **kwargs):
         if related_type:
             assert related_type in [NODES]
             base.path.segments.append(related_type)
+            user_nodes = _ensure_trailing_slash(base.url)
+            user_nodes += '?filter[registration]=false'
+            return user_nodes
     elif endpoint_type == NODES:
 
         base.path.segments.extend(['v2', NODES])


### PR DESCRIPTION
Purpose
-----------
Remove registrations from the nodes list.

Changes
-------------
Update api_url_for to add a query argument to the /users/me/nodes request. I'm not sure if I dealt with the trailing slash in the most efficient way, but it works and will be fine as long as we don't need additional query parameters added outside of that part of the code. You'll need to sync with OSF Develop as of around 11 this morning to test locally, but it's on staging.

Side effects
----------------
None.