### PR TITLE
[Feature] Alert user that they have not saved changes

### DIFF
--- a/osfoffline/views/preferences.py
+++ b/osfoffline/views/preferences.py
@@ -55,9 +55,12 @@ class Preferences(QDialog):
             reply = QMessageBox()
             reply.setText('Unsaved changes')
             reply.setIcon(QMessageBox.Warning)
-            reply.setInformativeText('You have unsaved changes to your synced projects.  Are you sure you would like to leave without saving?')
-            reply.addButton('Exit without saving', QMessageBox.YesRole)
-            reply.addButton('Review/Save changes', QMessageBox.NoRole)
+            reply.setInformativeText('You have unsaved changes to your synced projects.\n\n '
+                                     'Please review your changes and press \'update\' if you would like to save them. \n\n  '
+                                     'Are you sure you would like to leave without saving? \n')
+            default = reply.addButton('Exit without saving', QMessageBox.YesRole)
+            reply.addButton('Review changes', QMessageBox.NoRole)
+            reply.setDefaultButton(default)
             test = reply.exec_()
             if test == 0:
                 event.accept()


### PR DESCRIPTION
Purpose
-
Previously a user would not be notified that they had not saved their changes when select which projects should be synced and which to ignore.  This meant that a user may make a bunch of changes, close out of the window, and then be confused as to why nothing was being synced.  This PR seeks to address this issue by opening a window alerting the user that they have unsaved changes (if applicable)

<img width="459" alt="screen shot 2015-11-09 at 2 42 45 pm" src="https://cloud.githubusercontent.com/assets/8229937/11044492/3554a8ec-86f0-11e5-80f2-151514e35cb6.png">

Changes
-
First I added a list field to the class to keep track of which projects were checked the last time the project was saved.  Then I bumped the code that creates guid_list out into its own method and called this inside of closeEvent and compared to the list of checked projects from the last save.  If they were equal, preferences closes normally, otherwise a message box pops up informing the user that they have unsaved changes.  They can either click a button to remain in preferences and review or save their changes or click a button to discard changes and close out of preferences.

Side effects
-
Due to the fact that this is predominately just a feature to improve UX there should not be any significant side effects.  There may be edge cases that cause the pop to show when it shouldn't or vice versa but the chances of this are pretty slim.

[#OSF-4409]