### PR TITLE
Fix DB error when two users share a computer 

### DIFF
--- a/osfoffline/database_manager/models.py
+++ b/osfoffline/database_manager/models.py
@@ -18,7 +18,7 @@ class User(Base):
 
     id = Column(Integer, primary_key=True)
     full_name = Column(String)
-    osf_login = Column(String, unique=True)
+    # osf_login = Column(String, unique=True)  # TODO: Re-enable when username/password login is done
     osf_password = Column(String)
     osf_local_folder_path = Column(String)
     oauth_token = Column(String)

--- a/osfoffline/views/start_screen.py
+++ b/osfoffline/views/start_screen.py
@@ -82,7 +82,7 @@ class StartScreen(QDialog):
                 user = User(
                     full_name=remote_user.name,
                     osf_id=remote_user.id,
-                    osf_login='',  # TODO: email goes here when more auth methods are added, not currently returned by APIv2
+                    # osf_login='',  # TODO: email goes here when more auth methods are added, not currently returned by APIv2
                     osf_local_folder_path='',
                     oauth_token=personal_access_token,
                 )


### PR DESCRIPTION
## Purpose
Fix an error reported by @nicipfeiffer  and @NatashaRichter in which trying to log out (then in as a different user) would give a database-related error message. ("Unable to save user data; please try again later")

## Summary of changes
Disabled the `osf_login` field of the database model. It is intended to only contain an email address, and in the absence of that data, every single user was being given the same placeholder value. 

Since this violated the `unique` constraint on that field, users were seeing an error message.

## Side effects
Didn't update the tests- they were already broken, and likely will remain so until after this field is needed again. (we will begin collecting email addresses as part of #26 )