### PR TITLE
Refactored preferences to no longer use node name as a dependancy

### DIFF
--- a/osfoffline/utils/path.py
+++ b/osfoffline/utils/path.py
@@ -117,6 +117,16 @@ class ProperPath(object):
     def __repr__(self):
         return self.full_path
 
+def make_folder_name(name, node_id=None):
+    """ Helper function to generate non-conflicting folder names
+    :param str name:    Name of folder on OSF
+    :param str node_id: Optional - osf_id of folder
+    :return:            Generated approximately unique name
+    """
+    if node_id:
+        return '{} - {}'.format(name, node_id)
+    else:
+        return name
 
 def ensure_folders(path):
     """Ensure that the specified folder (and all folders in path) exists"""

--- a/osfoffline/views/preferences.py
+++ b/osfoffline/views/preferences.py
@@ -41,10 +41,8 @@ class Preferences(QDialog):
     def get_guid_list(self):
         guid_list = []
         for tree_item in self.tree_items:
-            for name, id in [(node.name, node.id) for node in self.remote_top_level_nodes]:
-                if name == tree_item.text(self.PROJECT_NAME_COLUMN):
-                    if tree_item.checkState(self.PROJECT_SYNC_COLUMN) == Qt.Checked:
-                        guid_list.append(id)
+            if tree_item[0].checkState(self.PROJECT_SYNC_COLUMN) == Qt.Checked:
+                guid_list.append(tree_item[1])
         return guid_list
 
     def closeEvent(self, event):
@@ -160,7 +158,7 @@ class Preferences(QDialog):
                     self.checked_items.append(node.id)
             self.preferences_window.treeWidget.resizeColumnToContents(self.PROJECT_NAME_COLUMN)
 
-            self.tree_items.append(tree_item)
+            self.tree_items.append((tree_item, node.id))
 
     def get_remote_top_level_nodes(self):
         remote_top_level_nodes = []

--- a/osfoffline/views/preferences.py
+++ b/osfoffline/views/preferences.py
@@ -11,6 +11,7 @@ from osfoffline.polling_osf_manager.api_url_builder import api_url_for, NODES, U
 from osfoffline.polling_osf_manager.remote_objects import RemoteNode
 import requests
 import osfoffline.alerts as AlertHandler
+from osfoffline.utils import path
 
 class Preferences(QDialog):
     """
@@ -40,9 +41,9 @@ class Preferences(QDialog):
 
     def get_guid_list(self):
         guid_list = []
-        for tree_item in self.tree_items:
-            if tree_item[0].checkState(self.PROJECT_SYNC_COLUMN) == Qt.Checked:
-                guid_list.append(tree_item[1])
+        for tree_item, node_id in self.tree_items:
+            if tree_item.checkState(self.PROJECT_SYNC_COLUMN) == Qt.Checked:
+                guid_list.append(node_id)
         return guid_list
 
     def closeEvent(self, event):
@@ -150,15 +151,16 @@ class Preferences(QDialog):
         for node in self.remote_top_level_nodes:
             tree_item = QTreeWidgetItem(self.preferences_window.treeWidget)
             tree_item.setCheckState(self.PROJECT_SYNC_COLUMN, Qt.Unchecked)
-            tree_item.setText(self.PROJECT_NAME_COLUMN, _translate("Preferences", node.name))
+            tree_item.setText(self.PROJECT_NAME_COLUMN, _translate("Preferences", path.make_folder_name(node.name, node_id=node.id)))
 
             if node.id in user.guid_for_top_level_nodes_to_sync:
                 tree_item.setCheckState(self.PROJECT_SYNC_COLUMN, Qt.Checked)
                 if node.id not in self.checked_items:
                     self.checked_items.append(node.id)
-            self.preferences_window.treeWidget.resizeColumnToContents(self.PROJECT_NAME_COLUMN)
 
             self.tree_items.append((tree_item, node.id))
+        self.preferences_window.treeWidget.resizeColumnToContents(self.PROJECT_SYNC_COLUMN)
+        self.preferences_window.treeWidget.resizeColumnToContents(self.PROJECT_NAME_COLUMN)
 
     def get_remote_top_level_nodes(self):
         remote_top_level_nodes = []


### PR DESCRIPTION
Purpose
-
Previously there was a double for loop comparing tree item names with node names to link the two together.  This poses two problems:
 1) It is O(n^2) time when it could be O(n) and this is slow with large numbers of nodes.
 2) If two nodes have the same name it may link the wrong things

Changes
-
Changed tree_items to be a list of tuples so that the first tuple index is the tree_item and the second is the node id.  This allows us to do one loop and then get the part we need and they will always be linked together properly.

Side Effects
-
Should not be any because everything should be linked properly.

[#OSF-5152]