### PR TITLE
[Feature][Fix] unique project folder names

### DIFF
--- a/osfoffline/database_manager/models.py
+++ b/osfoffline/database_manager/models.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import relationship, backref, validates
 from sqlalchemy import Column, Integer, Boolean, String, DateTime
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.hybrid import hybrid_property
+from osfoffline.utils.path import make_folder_name
 
 Base = declarative_base()
 
@@ -100,10 +101,9 @@ class Node(Base):
         # +os.path.sep+ instead of os.path.join: http://stackoverflow.com/a/14504695
 
         if self.parent:
-            return os.path.join(self.parent.path, 'Components', self.title)
+            return os.path.join(self.parent.path, 'Components', make_folder_name(self.title, self.osf_id))
         else:
-
-            return os.path.join(self.user.osf_local_folder_path, self.title)
+            return os.path.join(self.user.osf_local_folder_path, make_folder_name(self.title, self.osf_id))
 
     def locally_create_children(self):
         self.locally_created = True
@@ -212,10 +212,16 @@ class File(Base):
         """Recursively walk up the path of the file/folder. Top level file/folder joins with the path of the containing node.
         """
         # +os.path.sep+ instead of os.path.join: http://stackoverflow.com/a/14504695
-        if self.parent:
-            return os.path.join(self.parent.path, self.name)
+        if self.type == self.FILE:
+            if self.parent:
+                return os.path.join(self.parent.path, self.name)
+            else:
+                return os.path.join(self.node.path, self.name)
         else:
-            return os.path.join(self.node.path, self.name)
+            if self.parent:
+                return os.path.join(self.parent.path, make_folder_name(self.name, self.osf_id))
+            else:
+                return os.path.join(self.node.path, make_folder_name(self.name, self.osf_id))
 
     def update_hash(self, block_size=2 ** 20):
         if self.is_file:

--- a/osfoffline/database_manager/models.py
+++ b/osfoffline/database_manager/models.py
@@ -101,9 +101,9 @@ class Node(Base):
         # +os.path.sep+ instead of os.path.join: http://stackoverflow.com/a/14504695
 
         if self.parent:
-            return os.path.join(self.parent.path, 'Components', make_folder_name(self.title, self.osf_id))
+            return os.path.join(self.parent.path, 'Components', make_folder_name(self.title, node_id=self.osf_id))
         else:
-            return os.path.join(self.user.osf_local_folder_path, make_folder_name(self.title, self.osf_id))
+            return os.path.join(self.user.osf_local_folder_path, make_folder_name(self.title, node_id=self.osf_id))
 
     def locally_create_children(self):
         self.locally_created = True
@@ -219,9 +219,9 @@ class File(Base):
                 return os.path.join(self.node.path, self.name)
         else:
             if self.parent:
-                return os.path.join(self.parent.path, make_folder_name(self.name, self.osf_id))
+                return os.path.join(self.parent.path, make_folder_name(self.name, node_id=self.osf_id))
             else:
-                return os.path.join(self.node.path, make_folder_name(self.name, self.osf_id))
+                return os.path.join(self.node.path, make_folder_name(self.name, node_id=self.osf_id))
 
     def update_hash(self, block_size=2 ** 20):
         if self.is_file:

--- a/osfoffline/filesystem_manager/osf_event_handler.py
+++ b/osfoffline/filesystem_manager/osf_event_handler.py
@@ -164,7 +164,7 @@ class OSFEventHandler(FileSystemEventHandler):
             item = self._get_item_by_path(src_path)
         except ItemNotInDB:
             # todo: create file folder
-            logging.warning('file was modified but not already in db. create it in db.')
+            logging.warning('file {} was modified but not already in db. create it in db.'.format(src_path))
             return  # todo: remove this once above is implemented
 
         # update hash

--- a/osfoffline/utils/path.py
+++ b/osfoffline/utils/path.py
@@ -117,6 +117,17 @@ class ProperPath(object):
     def __repr__(self):
         return self.full_path
 
+def make_folder_name(name, node_id=None):
+    """ Helper function to generate non-conflicting folder names
+
+    :param str name:    Name of folder on OSF
+    :param str node_id: Optional - osf_id of folder
+    :return:            Generated approximately unique name
+    """
+    if node_id:
+        return '{} - {}'.format(name, node_id)
+    else:
+        return name
 
 def ensure_folders(path):
     """Ensure that the specified folder (and all folders in path) exists"""


### PR DESCRIPTION
Purpose
======
On the OSF, you can have two projects with the same name. In a filesystem, having two directories of the same name in the same location doesn't work as well. 

Changes
=======
Append node/folder ID from the OSF to the name when creating a folder path

Side Effects
=========
* Improved logging for a `todo handle exception`.
* None found during testing. (But other unrelated bugs uncovered during testing)

[#OSF-4408]