### PR TITLE
[Feature] Don't delete on modify

### DIFF
--- a/osfoffline/filesystem_manager/osf_event_handler.py
+++ b/osfoffline/filesystem_manager/osf_event_handler.py
@@ -4,6 +4,7 @@ storing the data into the db, and then sending a request to the remote server.
 """
 import asyncio
 import logging
+import os
 
 from watchdog.events import FileSystemEventHandler, DirModifiedEvent, DirCreatedEvent, FileCreatedEvent
 from osfoffline.database_manager.models import Node, File, User
@@ -203,18 +204,18 @@ class OSFEventHandler(FileSystemEventHandler):
         # get item
         item = self._get_item_by_path(src_path)
 
-        # put item in delete state
-        item.locally_deleted = True
-
-        # nodes cannot be deleted online. THUS, delete it inside database. It will be recreated locally.
-        if isinstance(item, Node):
-            session.delete(item)
-            save(session)
-            return
-
-        save(session, item)
-
-        logging.info('{} set to be deleted'.format(src_path.full_path))
+        # put item in delete state after waiting a second and
+        # checking to make sure the file was actually deleted
+        yield from asyncio.sleep(1)
+        if not os.path.exists(item.path):
+            item.locally_deleted = True
+            # nodes cannot be deleted online. THUS, delete it inside database. It will be recreated locally.
+            if isinstance(item, Node):
+                session.delete(item)
+                save(session)
+                return
+            save(session, item)
+            logging.info('{} set to be deleted'.format(src_path.full_path))
 
     def dispatch(self, event):
         # basically, ignore all events that occur for 'Components' file or folder

--- a/osfoffline/filesystem_manager/osf_event_handler.py
+++ b/osfoffline/filesystem_manager/osf_event_handler.py
@@ -214,7 +214,10 @@ class OSFEventHandler(FileSystemEventHandler):
             # nodes cannot be deleted online. THUS, delete it inside database. It will be recreated locally.
             if isinstance(item, Node):
                 session.delete(item)
-                save(session)
+                try:
+                    save(session)
+                except SQLAlchemyError as e:
+                    logging.warning(e.message)
                 return
             try:
                 save(session, item)


### PR DESCRIPTION
Purpose
======
Close previously unknown bug. When a file is modified, the OS typically uses temp files. In many cases, this causes what should be viewed as a modify event to be a delete event, presumably because the original file is deleted and the temp file is renamed to the original file in one action.

Changes
=======
On delete, sleep for a second to make sure any filesystem changes are finished, then check to see if the file still exists on disk. If it does, don't delete it remotely.

Side Effects
=========
None 