### PR TITLE
make component folder only show up when ther is child node

### DIFF
--- a/osfoffline/polling_osf_manager/polling.py
+++ b/osfoffline/polling_osf_manager/polling.py
@@ -725,8 +725,9 @@ class Poll(object):
 
     def _ensure_components_folder(self, local_node):
         assert isinstance(local_node, Node)
-        self.polling_event_queue.put(
-            CreateFolder(
-                os.path.join(local_node.path, 'Components')
+        if local_node.child_nodes:
+            self.polling_event_queue.put(
+                CreateFolder(
+                    os.path.join(local_node.path, 'Components')
+                )
             )
-        )


### PR DESCRIPTION
Only create 'component' folder when the nodes actually has a child node. fixes https://openscience.atlassian.net/browse/OSF-5145